### PR TITLE
Use a next rewrite to avoid the api host in env vars

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,0 @@
-# DO NOT ADD SECRETS TO THIS FILE. This is a good place for defaults.
-# If you want to add secrets use `.env.development.local` instead.
-NEXT_PUBLIC_COIN_API="http://nuc:6970/api"

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,0 @@
-# DO NOT ADD SECRETS TO THIS FILE. This is a good place for defaults.
-# If you want to add secrets use `.env.production.local` instead.
-NEXT_PUBLIC_COIN_API="https://koicoin-api.guigurl.com/api"

--- a/next.config.js
+++ b/next.config.js
@@ -2,8 +2,19 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
-    unoptimized: true
-  }
-}
+    unoptimized: true,
+  },
 
-module.exports = nextConfig
+  async rewrites() {
+    const host = process.env.NEXT_PUBLIC_COIN_API || 'http://localhost:6969';
+
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${host}/api/:path*`,
+      },
+    ];
+  },
+};
+
+module.exports = nextConfig;

--- a/src/ui/middleware/ledgerMiddleware.ts
+++ b/src/ui/middleware/ledgerMiddleware.ts
@@ -8,14 +8,12 @@ import {
 import { takeEvery } from './middleware';
 
 export async function getTransactionForAddress<T extends ActionIdentity>(
-  action: T
+  action: T,
 ): Promise<Action> {
   const address = action.payload!.address;
 
   try {
-    const response: Response = await fetch(
-      `${process.env.NEXT_PUBLIC_COIN_API}/addresses/${address}`
-    );
+    const response: Response = await fetch(`/api/addresses/${address}`);
     const result: ApiResponse = await response.json();
 
     if (!response.ok) {
@@ -36,19 +34,16 @@ export async function getTransactionForAddress<T extends ActionIdentity>(
 }
 
 export async function sendCoins<T extends ActionIdentity>(
-  action: T
+  action: T,
 ): Promise<Action> {
   try {
-    const response: Response = await fetch(
-      `${process.env.NEXT_PUBLIC_COIN_API}/transactions`,
-      {
-        method: 'POST',
-        body: JSON.stringify(action.payload),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
-    );
+    const response: Response = await fetch(`/api/transactions`, {
+      method: 'POST',
+      body: JSON.stringify(action.payload),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
     const result: ApiResponse = await response.json();
 
     if (!response.ok) {
@@ -71,7 +66,7 @@ export async function sendCoins<T extends ActionIdentity>(
 export function* ledgerMiddleware() {
   yield takeEvery(
     ActionTypes.getTransactionsForAddress,
-    getTransactionForAddress
+    getTransactionForAddress,
   );
   yield takeEvery(ActionTypes.sendCoins, sendCoins);
 }


### PR DESCRIPTION
Adds a rewrite rule into `next.config.js` that, for the dev server only, rewrites `/api` to a local address. This allows us to handle production routing at the infrastructure level, instead of requiring a code deploy.

This means the `.env` files are no longer necessary. Local development will assume the api server is at `http://localhost:6969`. This can still be overwritten with the `NEXT_PUBLIC_COIN_API` environment variable.

Setting `NEXT_PUBLIC_COIN_API` only affects the development server. The production build will always assume the api server responds to the same host (i.e., API requests now go to `/api/path`, instead of `http://api-server/api/path`).