### PR TITLE
Use correct package manager in workflows

### DIFF
--- a/.github/workflows/development_build.yml
+++ b/.github/workflows/development_build.yml
@@ -1,28 +1,34 @@
 name: Development Build
 
 on:
-  pull_request:
-    branches:
-      - main
+  push:
+    branches-ignore:
+      -main
+  workflow_dispatch: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: '14.x'
+          node-version: 'lts/*'
 
-      - uses: actions/cache@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        id: yarn-cache
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-yarn-
 
-      - run: npm install
+      - run: yarn install
 
-      - run: npm run build
+      - run: yarn run build

--- a/.github/workflows/prod_build.yml
+++ b/.github/workflows/prod_build.yml
@@ -10,22 +10,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: '14.x'
+          node-version: 'lts/*'
 
-      - uses: actions/cache@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        id: yarn-cache
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-yarn-
 
-      - run: npm install
+      - run: yarn install
 
-      - run: npm run build
+      - run: yarn run build
 
       - name: Rsync Deployments Action
         uses: Burnett01/rsync-deployments@4.1


### PR DESCRIPTION
Workflows were using npm, but a `yarn.lock` file was controlling dependencies. This created a discrepancy that resulted in failed compiles. This change resolves that by using yarn in CI as well.

Also updates GitHub actions to newer versions.